### PR TITLE
Add browser interactions to trial data

### DIFF
--- a/experiment.js
+++ b/experiment.js
@@ -325,6 +325,12 @@ jsPsych.init({
             lastTrial.tripletType = "L" //low-probability triplet
         }
     }
+        /*add browser events in JSON format*/
+        let interactionData = jsPsych.data.getInteractionData()
+        const interactionDataOfLastTrial = interactionData.filter({'trial': lastTrial.trial_index}).values();
+        if (interactionDataOfLastTrial) {
+            lastTrial.browserEvents = JSON.stringify(interactionDataOfLastTrial)
+        }
     }
     ,
     on_finish: function () {


### PR DESCRIPTION
[Browser interactions](https://www.jspsych.org/core_library/jspsych-data/#jspsychdatagetinteractiondata) (e.g. blur, focus events) are added to trial data in JSON format

Example of browser interactions from jsPsych documentation:
```javascript
{
    type: 'focus' or 'blur' or 'fullscreenenter' or 'fullscreenexit',
    trial: 10, // the trial number when the event happened
    time: 13042 // total time elapsed since the start of the experiment
}
```

On each data update:
- interactions data is filtered for the last trial 
- if browser events exist for last trial, unprocessed browser events are added to existing data collection (`lastTrial`)

Example of the data structure of browser events during a trial (`lastTrial.browserEvents`):
```json
[{"event":"blur","trial":0,"time":1610},
{"event":"focus","trial":0,"time":3268},
{"event":"blur","trial":0,"time":4811},
{"event":"focus","trial":0,"time":6286}]
```